### PR TITLE
Mark `calamares` config files with %config directive

### DIFF
--- a/distro-release.spec
+++ b/distro-release.spec
@@ -1231,8 +1231,8 @@ sed -i -e "s/#PRODUCT_ID/$(cat /etc/product.id)/" -e "s/#LANG/${LC_NAME/[-_]*}/g
 %{_rpmconfigdir}/fileattrs/kmod.attr
 
 %files installer
-%{_sysconfdir}/calamares/*.conf
-%{_sysconfdir}/calamares/modules/*.conf
+%config %{_sysconfdir}/calamares/*.conf
+%config %{_sysconfdir}/calamares/modules/*.conf
 %{_sysconfdir}/calamares/branding/auto/*
 
 %files indexhtml


### PR DESCRIPTION
calamares config files aren't marked as configs and because of that are showing as modified on a clean LXQt installation medium:

```
[live@omv-3497 ~]$ rpm -V --noconfig distro-release-installer
S.5......    /etc/calamares/modules/displaymanager.conf
```

Stuff in `/etc/calamares/branding/` looks like static files (images, etc.), so I left it as is.